### PR TITLE
Add support for custom eval function that can return promise

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -1401,6 +1401,10 @@ JanewayClass.setMethod(function start(options, callback) {
 		screen = options.screen;
 	}
 
+	if (options.customEval && typeof options.customEval === 'function') {
+		this._customEval = options.customEval;
+	}
+
 	// Store the options
 	this.options = options;
 
@@ -2492,11 +2496,19 @@ JanewayClass.setMethod(async function evaluate(source) {
 
 		// Run the command in the custom context
 		try {
-			// Force it to become an expression first
-			result = vm.runInNewContext('(' + code + ')', vm_context, vm_options);
+			if (this._customEval) {
+				result = this._customEval(code);
+			} else {
+				// Force it to become an expression first
+				result = vm.runInNewContext('(' + code + ')', vm_context, vm_options);
+			}
 		} catch (err) {
 			// In case it failed, try without parentheses
 			result = vm.runInNewContext(code, vm_context, vm_options);
+		}
+
+		if (result instanceof Promise) {
+			expect_promise = true;
 		}
 
 		// Create a line for the output


### PR DESCRIPTION
We have a use case that certain code that performs db access needs to run inside node fiber environment and we have to wait for the action to complete. So I added support for a custom evaluate function that can return a promise . 
Thanks for your consideration! 